### PR TITLE
CI: Use newer Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - rbx-19mode
+  - 2.4
+  - 2.5
+  - 2.6

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'http://rubygems.org'
 gem 'rake'
+gem "test-unit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,17 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    power_assert (1.1.6)
     rake (10.1.0)
+    test-unit (3.3.5)
+      power_assert
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   rake
+  test-unit
+
+BUNDLED WITH
+   2.0.2

--- a/lib/skanetrafiken/line.rb
+++ b/lib/skanetrafiken/line.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 module Skanetrafiken
   class Line < Struct.new(:name,:no,:journey_date_time,:is_timing_point,\
-      :stop_point,:line_type_id,:line_type_id,:line_type_name,\
+      :stop_point,:line_type_id,:line_type_name,\
       :towards)
 
     include StructInitializer


### PR DESCRIPTION
This PR updates the CI configuration to use supported Ruby versions only.